### PR TITLE
Changing name to Software Crafters Sydney

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 </p>
 
 <p align="center">
-  <a href="http://slack.softwarecraftsmanship.org/"><img src="http://slack.softwarecraftsmanship.org/badge.svg"></a>
-  <a href="https://www.meetup.com/en-AU/Software-Craftsmanship-Sydney/"><img src="https://img.shields.io/badge/%F0%9D%93%B6%20meetup.com-SoftwareCraftsmanshipSydney-red.svg"></a>
+  <a href="http://slack.softwarecrafters.org/"><img src="http://slack.softwarecrafters.org/badge.svg"></a>
+  <a href="https://www.meetup.com/en-AU/Software-Crafters-Sydney/"><img src="https://img.shields.io/badge/%F0%9D%93%B6%20meetup.com-SoftwareCraftersSydney-red.svg"></a>
 </p>
 
 ---
 
-If you're wanting to request or submit a topic for **Software Craftsmanship Sydney** group, head for the <a href="https://github.com/SoftwareCraftsmanshipSydney/events/issues">issues page</a>.
+If you're wanting to request or submit a topic for **Software Crafters Sydney** group, head for the <a href="https://github.com/SoftwareCraftsmanshipSydney/events/issues">issues page</a>.
 
-After joining the [Slack group](http://slack.softwarecraftsmanship.org/), please [`#introduce_yourself`](https://softwarecraftsmanship.slack.com/messages/introduce_yourself/). Then join the [`#sydney`](https://softwarecraftsmanship.slack.com/messages/sydney/) and [`#australia`](https://softwarecraftsmanship.slack.com/messages/australia/) channels to stay in touch with us :smile:
+After joining the [Slack group](http://slack.softwarecrafters.org/), please [`#introduce_yourself`](https://softwarecrafters.slack.com/messages/introduce_yourself/). Then join the [`#sydney`](https://softwarecrafters.slack.com/messages/sydney/) and [`#australia`](https://softwarecrafters.slack.com/messages/australia/) channels to stay in touch with us :smile:


### PR DESCRIPTION
@alabeduarte @gtramontina @ThibautGery @ttsui

Just to keep sync with https://softwarecrafters.slack.com/messages/slack-rename-discuss/ and groups around the world https://www.meetup.com/es-ES/preview/madswcraft, https://www.meetup.com/en-AU/preview/Software-Crafters-Bilbao, etc...